### PR TITLE
Set proper `jvm_language_level` to 17

### DIFF
--- a/course-info.yaml
+++ b/course-info.yaml
@@ -7,4 +7,4 @@ content:
   - introductionSection
   - psiSection
 environment_settings:
-  jvm_language_level: JDK_20
+  jvm_language_level: JDK_17


### PR DESCRIPTION
IntelliJ plugin development requires JDK 17 at this moment. So, there is no reason to request anything higher from users